### PR TITLE
Add CC0 license fallback and fix grammatical error

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -13,16 +13,22 @@
 This is a free work delivered for educational purposes during the main course
 at 42 <42.fr>.
 
-Feel free to use it, change it, give advices, send me a pull request or
-just slack me if you want to share some thoughts.
+You are free to use, modify, and share this software. Contributions,
+suggestions, and pull requests are welcome! Feel free to contact me if you want
+to share thoughts.
 
-In jurisdictions that recognize copyright laws, the author or authors
-of this software dedicate any and all copyright interest in the
-software to the public domain. We make this dedication for the benefit
-of the public at large and to the detriment of our heirs and
-successors. We intend this dedication to be an overt act of
-relinquishment in perpetuity of all present and future rights to this
+In jurisdictions that recognize copyright laws, the author(s) of this software
+dedicate any and all copyright interest in the software to the public domain.
+This dedication is made for the benefit of the public at large and to the
+detriment of our heirs and successors. We intend this dedication to be an overt
+act of relinquishment in perpetuity of all present and future rights to this
 software under copyright law.
+
+If the Unlicense public domain dedication is not valid in your jurisdiction,
+you may use this software under the terms of the Creative Commons Zero v1.0
+Universal (CC0 1.0) License:
+
+https://creativecommons.org/publicdomain/zero/1.0/legalcode
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF

--- a/README.md
+++ b/README.md
@@ -21,8 +21,15 @@ To reference your **README** you can copy the following baseline:
 This work is published under the terms of **[42 Unlicense](https://github.com/gcamerli/42unlicense)**.
 ```
 
+### **License Features**
+
+- Places your code in the public domain
+- Includes CC0 1.0 Universal fallback for jurisdictions where public domain dedications are not recognized
+- Simple and permissive - no attribution required
+
 ### **Other remarkable public licenses**
 
 + [Unlicense](https://en.wikipedia.org/wiki/Unlicense)
++ [Creative Commons Zero (CC0)](https://creativecommons.org/publicdomain/zero/1.0/)
 + [Beerware](https://en.wikipedia.org/wiki/Beerware)
 + [WTFPL](https://en.wikipedia.org/wiki/WTFPL)


### PR DESCRIPTION
This pull request addresses two issues:

1. Fixes #1: Added CC0 1.0 Universal license fallback for jurisdictions where public domain dedications are not recognized
2. Fixes #2: Fixed grammatical error by replacing "advices" with "advice" and improving the wording

Changes made:
- Updated LICENSE file to include CC0 fallback clause
- Improved wording in the LICENSE file
- Updated README.md to mention the CC0 fallback feature
- Added a "License Features" section to README.md

These changes maintain the original intent of the license while improving its legal coverage and fixing grammatical issues.